### PR TITLE
Add "Central Indonesian Time"

### DIFF
--- a/lib/barometer/data/translations/zone_codes.yml
+++ b/lib/barometer/data/translations/zone_codes.yml
@@ -49,6 +49,7 @@ CET : 1
 CHADT : 13.75
 CHAST : 12.75
 CHST : 10
+CIT : 8
 CKT : -10
 CLST : -3
 CLT : -4


### PR DESCRIPTION
Wunderground returns this time zone as "CIT" for Indonesia (aka "WITA")

Issue #30
