### PR TITLE
Specify in README that it won't do historical data

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ support the query directly. See the "[Queries](#queries)" section for more info.
 * provides a simple plugin api to allow more weather services to be added
 * failover configuration
 * multiple services configuration to provide average values
+* DOES NOT RETURN HISTORICAL DATA
 
 ## Usage
 


### PR DESCRIPTION
I spent 2 hours on this gem wondering why it kept returning nil. If supporting historical temperatures isn't a feature and isn't on the roadmap, that should be super clear in the README.
